### PR TITLE
feat: Update Node.js requirement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "typescript": "^5.4.5"
       },
       "engines": {
-        "node": ">= 20.0.0"
+        "node": ">= 20.12.0"
       },
       "peerDependencies": {
         "typescript": "^5.4.5"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "wakamsha's generic tsconfig.",
   "engines": {
-    "node": ">= 20.0.0"
+    "node": ">= 20.12.0"
   },
   "files": [
     "LICENSEE",


### PR DESCRIPTION
BREAKING CHANGE:

- Update Node.js engine requirement to `>= 20.12.0`. This means we are dropping support for Node 20 versions prior to `20.12.0`.